### PR TITLE
Fixed Dockerfile_build jar file copy step

### DIFF
--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -14,8 +14,9 @@ RUN mvn package
 # ENTRYPOINT java -jar /code/target/javafxlibrary-*-SNAPSHOT-jar-with-dependencies.jar
 
 FROM ubuntu:16.04
-COPY --from=builder /code/target/javafxlibrary-*-SNAPSHOT-jar-with-dependencies.jar /.
-COPY --from=builder /code/target/javafxlibrary-*-SNAPSHOT-tests.jar /.
+COPY --from=builder /code/target/javafxlibrary-*-jar-with-dependencies.jar /.
+COPY --from=builder /code/target/javafxlibrary-*-tests.jar /.
+RUN echo "Built following jar files" && ls -latr /*.jar
 COPY entrypoint_build.sh /.
 RUN apt-get -qq update && apt-get dist-upgrade -y  && apt-get install -qq --no-install-recommends --allow-unauthenticated -y \
   openjdk-8-jre \


### PR DESCRIPTION
… Dockerfile_build, added print of jar files #21 

Fixed incorrect jar filename with SNAPSHOT from jar file copy step in Dockerfile_build, print of built jar files added.