### PR TITLE
Fix docker-compose up

### DIFF
--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -14,8 +14,8 @@ RUN mvn package
 # ENTRYPOINT java -jar /code/target/javafxlibrary-*-SNAPSHOT-jar-with-dependencies.jar
 
 FROM ubuntu:16.04
-COPY --from=builder /code/target/javafxlibrary-*-jar-with-dependencies.jar /.
-COPY --from=builder /code/target/javafxlibrary-*-tests.jar /.
+COPY --from=builder /code/target/javafxlibrary-*-jar-with-dependencies.jar /
+COPY --from=builder /code/target/javafxlibrary-*-tests.jar /
 RUN echo "Built following jar files" && ls -latr /*.jar
 COPY entrypoint_build.sh /.
 RUN apt-get -qq update && apt-get dist-upgrade -y  && apt-get install -qq --no-install-recommends --allow-unauthenticated -y \

--- a/docker/robot-javafx-demo/Dockerfile
+++ b/docker/robot-javafx-demo/Dockerfile
@@ -1,4 +1,4 @@
-FROM dorowu/ubuntu-desktop-lxde-vnc
+FROM dorowu/ubuntu-desktop-lxde-vnc:bionic
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Building the docker demo failed because of missing package versions for the newer Ubuntu image. Base image of the demo is now fixed to bionic tag since Ubuntu updates have broken the build earlier as well: https://github.com/eficode/JavaFXLibrary/commit/459329798751257d26f168582a7ad5de8a09fc1b

Closes #41 

Related Launchpad ticket:
https://bugs.launchpad.net/ubuntu/+source/openjfx/+bug/1799946